### PR TITLE
Removed Copy-Frameworks build phase

### DIFF
--- a/MutableCollectionProperty.xcodeproj/project.pbxproj
+++ b/MutableCollectionProperty.xcodeproj/project.pbxproj
@@ -17,8 +17,6 @@
 		23B531A61BCF7E96006656E3 /* Quick.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 23B531A41BCF7E96006656E3 /* Quick.framework */; };
 		23B531A91BCF7EE9006656E3 /* Nimble.framework in Copy Frameworks */ = {isa = PBXBuildFile; fileRef = 23B531A31BCF7E96006656E3 /* Nimble.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		23B531AA1BCF7EE9006656E3 /* Quick.framework in Copy Frameworks */ = {isa = PBXBuildFile; fileRef = 23B531A41BCF7E96006656E3 /* Quick.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
-		23B531AB1BCF7F02006656E3 /* ReactiveCocoa.framework in Copy frameworks */ = {isa = PBXBuildFile; fileRef = 23AE4B401BCE5D9E00D1082B /* ReactiveCocoa.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
-		23B531AC1BCF7F02006656E3 /* Result.framework in Copy frameworks */ = {isa = PBXBuildFile; fileRef = 23AE4B411BCE5D9E00D1082B /* Result.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		23B531AD1BCF87B6006656E3 /* ReactiveCocoa.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 23AE4B401BCE5D9E00D1082B /* ReactiveCocoa.framework */; };
 		23B531AE1BCF87C9006656E3 /* ReactiveCocoa.framework in Copy Frameworks */ = {isa = PBXBuildFile; fileRef = 23AE4B401BCE5D9E00D1082B /* ReactiveCocoa.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		23B531AF1BCF87CD006656E3 /* Result.framework in Copy Frameworks */ = {isa = PBXBuildFile; fileRef = 23AE4B411BCE5D9E00D1082B /* Result.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
@@ -36,18 +34,6 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXCopyFilesBuildPhase section */
-		23B531A71BCF7EC7006656E3 /* Copy frameworks */ = {
-			isa = PBXCopyFilesBuildPhase;
-			buildActionMask = 2147483647;
-			dstPath = "";
-			dstSubfolderSpec = 10;
-			files = (
-				23B531AB1BCF7F02006656E3 /* ReactiveCocoa.framework in Copy frameworks */,
-				23B531AC1BCF7F02006656E3 /* Result.framework in Copy frameworks */,
-			);
-			name = "Copy frameworks";
-			runOnlyForDeploymentPostprocessing = 0;
-		};
 		23B531A81BCF7EDD006656E3 /* Copy Frameworks */ = {
 			isa = PBXCopyFilesBuildPhase;
 			buildActionMask = 2147483647;
@@ -174,7 +160,6 @@
 				23AE4B211BCE5CF100D1082B /* Frameworks */,
 				23AE4B221BCE5CF100D1082B /* Headers */,
 				23AE4B231BCE5CF100D1082B /* Resources */,
-				23B531A71BCF7EC7006656E3 /* Copy frameworks */,
 			);
 			buildRules = (
 			);


### PR DESCRIPTION
This was causing the dependent frameworks to be copied with all archs. Including [x86_64, i386] that causes an issue when submitting to the App Store. See https://github.com/Carthage/Carthage/issues/416 and https://github.com/Carthage/Carthage/issues/353 for more info.

The tests still seems to work for me without this. This will require that the user of this framework provide the ReactiveCocoa och Result framework there selfes. But should fix the App Store submit problem.